### PR TITLE
chore: fixed phpstan.neon.dist.stub with larastan include

### DIFF
--- a/stubs/phpstan.neon.dist.stub
+++ b/stubs/phpstan.neon.dist.stub
@@ -1,4 +1,5 @@
 includes:
+    - ./vendor/larastan/larastan/extension.neon
 
 parameters:
 


### PR DESCRIPTION
This pull request includes a small change to the `stubs/phpstan.neon.dist.stub` file. The change adds a new include directive for the Larastan extension.

* [`stubs/phpstan.neon.dist.stub`](diffhunk://#diff-a70710113244b63e8b3a105dae0a1f6348971d6cf4c6a49553e092bb072dd02aR2): Added an include directive for the Larastan extension.